### PR TITLE
Add options to externalise showcase storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+* Added callbacks to externalize showcase state.
+
 ## [0.2.0+4] - 2020-08-05
 
 * Updated README.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The showcase is where everything begins. Let's see the available options :
 * `child` The widget to display below the slides. It should be your app main widget.
 * `counterText` The current slide counter text. `:i` targets the current slide number and `:n` targets the maximum slide number.
 * `showCloseButton` Whether to show a little close button on the top left of the slide.
+* `isSlideVisible` Checks if given slide should be shown to the user.
+* `hideSlide` Mark given slide as hidden.
 
 ### The slides
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   bubble_showcase:
     dependency: "direct dev"
     description:
@@ -28,35 +28,35 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   file:
     dependency: transitive
     description:
@@ -92,21 +92,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -188,7 +188,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   speech_bubble:
     dependency: "direct dev"
     description:
@@ -202,49 +202,49 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -253,5 +253,5 @@ packages:
     source: hosted
     version: "0.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:bubble_showcase/src/slide.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Contains some useful methods.
 class Utils {
@@ -84,4 +87,21 @@ class OverlayPainter extends CustomPainter {
   @override
   bool shouldRepaint(OverlayPainter oldOverlay) =>
       oldOverlay._position != _position;
+}
+
+Future<bool> readShowcaseStateFromSharedPreferences(
+  String showcaseId,
+  int showcaseVersion,
+) async {
+  final SharedPreferences preferences = await SharedPreferences.getInstance();
+  bool result = preferences.getBool('$showcaseId.$showcaseVersion');
+  return result == null || result;
+}
+
+FutureOr<void> setShowcaseStateToSharedPreferences(
+  String showcaseId,
+  int showcaseVersion,
+) async {
+  final preferences = await SharedPreferences.getInstance();
+  await preferences.setBool('${showcaseId}.${showcaseVersion}', false);
 }


### PR DESCRIPTION
Adds two callback functions to Showcase widget:
 * isSlideVisible
 * hideSlide

That allows to externalize slide visibility and control it from consumer
application code.

Both arguments have default values that stores data in
SharedPreferences, to keep the same default behaviour of library.

Main driver for this change is to improve end user experience when app
is used on multiple devices. In such case, state of slides may be stored
on the user profile and then ignored when app is started on a different
device.