### PR TITLE
feat: Allow the passthrough of pointer events inside the highlighted area

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,6 +28,9 @@ class _BubbleShowcaseDemoWidget extends StatelessWidget {
   /// The first button global key.
   final GlobalKey _firstButtonKey = GlobalKey();
 
+  /// The second button global key.
+  final GlobalKey _secondButtonKey = GlobalKey();
+
   @override
   Widget build(BuildContext context) {
     TextStyle textStyle = Theme.of(context).textTheme.bodyText2!.copyWith(
@@ -40,8 +43,13 @@ class _BubbleShowcaseDemoWidget extends StatelessWidget {
         _firstSlide(textStyle),
         _secondSlide(textStyle),
         _thirdSlide(textStyle),
+        _fourthSlide(textStyle),
       ],
-      child: _BubbleShowcaseDemoChild(_titleKey, _firstButtonKey),
+      child: _BubbleShowcaseDemoChild(
+        _titleKey,
+        _firstButtonKey,
+        _secondButtonKey,
+      ),
     );
   }
 
@@ -143,6 +151,46 @@ class _BubbleShowcaseDemoWidget extends StatelessWidget {
           ),
         ),
       );
+
+  /// Creates the fourth slide.
+  BubbleSlide _fourthSlide(TextStyle textStyle) => RelativeBubbleSlide(
+        highlightPadding: 4,
+        passThroughMode: PassthroughMode.INSIDE_WITH_NOTIFICATION,
+        widgetKey: _secondButtonKey,
+        shape: const Oval(
+          spreadRadius: 15,
+        ),
+        child: RelativeBubbleSlideChild(
+          widget: Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: SpeechBubble(
+              nipLocation: NipLocation.TOP,
+              color: Colors.blue,
+              child: Padding(
+                padding: const EdgeInsets.all(10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Going through!',
+                      style: textStyle.copyWith(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Text(
+                      'Passthrough is on!\nTo finish the tutorial, you need to click this button',
+                      style: textStyle,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
 }
 
 /// The main demo widget child.
@@ -152,9 +200,11 @@ class _BubbleShowcaseDemoChild extends StatelessWidget {
 
   /// The first button global key.
   final GlobalKey _firstButtonKey;
+  final GlobalKey _secondButtonKey;
 
   /// Creates a new bubble showcase demo child instance.
-  _BubbleShowcaseDemoChild(this._titleKey, this._firstButtonKey);
+  _BubbleShowcaseDemoChild(
+      this._titleKey, this._firstButtonKey, this._secondButtonKey);
 
   @override
   Widget build(BuildContext context) => Padding(
@@ -183,8 +233,13 @@ class _BubbleShowcaseDemoChild extends StatelessWidget {
               ),
             ),
             ElevatedButton(
-              onPressed: () {},
-              child: const Text('This button is old, please don\'t pay attention.'),
+              key: _secondButtonKey,
+              onPressed: () {
+                const BubbleShowcaseNotification()..dispatch(context);
+              },
+              child: const Text(
+                'This button is old, please don\'t pay attention.',
+              ),
             )
           ],
         ),

--- a/lib/src/shape.dart
+++ b/lib/src/shape.dart
@@ -7,6 +7,8 @@ abstract class Shape {
 
   /// Draw the shape on the specified canvas.
   void drawOnCanvas(Canvas canvas, Rect rectangle, Paint paint);
+
+  void makePath(Path path, Rect rectangle);
 }
 
 /// A rectangle shape.
@@ -22,6 +24,11 @@ class Rectangle extends Shape {
   @override
   void drawOnCanvas(Canvas canvas, Rect rectangle, Paint paint) {
     canvas.drawRect(rectangle.inflate(spreadRadius), paint);
+  }
+
+  @override
+  void makePath(Path path, Rect rectangle) {
+    path.addRect(rectangle);
   }
 }
 
@@ -41,7 +48,14 @@ class RoundedRectangle extends Shape {
 
   @override
   void drawOnCanvas(Canvas canvas, Rect rectangle, Paint paint) {
-    canvas.drawRRect(RRect.fromRectAndRadius(rectangle.inflate(spreadRadius), radius), paint);
+    canvas.drawRRect(
+        RRect.fromRectAndRadius(rectangle.inflate(spreadRadius), radius),
+        paint);
+  }
+
+  @override
+  void makePath(Path path, Rect rectangle) {
+    path.addRRect(RRect.fromRectAndRadius(rectangle, radius));
   }
 }
 
@@ -59,6 +73,11 @@ class Oval extends Shape {
   void drawOnCanvas(Canvas canvas, Rect rectangle, Paint paint) {
     canvas.drawOval(rectangle.inflate(spreadRadius), paint);
   }
+
+  @override
+  void makePath(Path path, Rect rectangle) {
+    path.addOval(rectangle.inflate(spreadRadius));
+  }
 }
 
 /// A circle shape.
@@ -75,5 +94,12 @@ class Circle extends Shape {
   void drawOnCanvas(Canvas canvas, Rect rectangle, Paint paint) {
     Rect circle = rectangle.inflate(spreadRadius);
     canvas.drawCircle(circle.center, circle.longestSide / 2, paint);
+  }
+
+  @override
+  void makePath(Path path, Rect rectangle) {
+    path.addOval(
+      Rect.fromCircle(center: rectangle.center, radius: rectangle.width / 2),
+    );
   }
 }

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -29,7 +29,7 @@ class BubbleShowcase extends StatefulWidget {
   final bool showCloseButton;
 
   // Duration by which delay showcase initialization.
-   final Duration initialDelay;
+  final Duration initialDelay;
 
   /// Creates a new bubble showcase instance.
   BubbleShowcase({
@@ -52,13 +52,15 @@ class BubbleShowcase extends StatefulWidget {
       return true;
     }
     SharedPreferences preferences = await SharedPreferences.getInstance();
-    bool? result = preferences.getBool('$bubbleShowcaseId.$bubbleShowcaseVersion');
+    bool? result =
+        preferences.getBool('$bubbleShowcaseId.$bubbleShowcaseVersion');
     return result == null || result;
   }
 }
 
 /// The BubbleShowcase state.
-class _BubbleShowcaseState extends State<BubbleShowcase> with WidgetsBindingObserver {
+class _BubbleShowcaseState extends State<BubbleShowcase>
+    with WidgetsBindingObserver {
   /// The current slide index.
   int currentSlideIndex = -1;
 
@@ -79,7 +81,11 @@ class _BubbleShowcaseState extends State<BubbleShowcase> with WidgetsBindingObse
   }
 
   @override
-  Widget build(BuildContext context) => widget.child;
+  Widget build(BuildContext context) =>
+      NotificationListener<BubbleShowcaseNotification>(
+        onNotification: processNotification,
+        child: widget.child,
+      );
 
   @override
   void dispose() {
@@ -98,8 +104,15 @@ class _BubbleShowcaseState extends State<BubbleShowcase> with WidgetsBindingObse
     });
   }
 
+  bool processNotification(BubbleShowcaseNotification notif) {
+    goToNextEntryOrClose(currentSlideIndex + 1);
+    return true;
+  }
+
   /// Returns whether the showcasing is finished.
-  bool get isFinished => currentSlideIndex == -1 || currentSlideIndex == widget.bubbleSlides.length;
+  bool get isFinished =>
+      currentSlideIndex == -1 ||
+      currentSlideIndex == widget.bubbleSlides.length;
 
   /// Allows to go to the next entry (or to close the showcase if needed).
   void goToNextEntryOrClose(int position) {
@@ -111,7 +124,9 @@ class _BubbleShowcaseState extends State<BubbleShowcase> with WidgetsBindingObse
       currentSlideEntry = null;
       if (widget.doNotReopenOnClose) {
         SharedPreferences.getInstance().then((preferences) {
-          preferences.setBool('${widget.bubbleShowcaseId}.${widget.bubbleShowcaseVersion}', false);
+          preferences.setBool(
+              '${widget.bubbleShowcaseId}.${widget.bubbleShowcaseVersion}',
+              false);
         });
       }
     } else {
@@ -135,7 +150,8 @@ class _BubbleShowcaseState extends State<BubbleShowcase> with WidgetsBindingObse
 
   /// Allows to trigger enter callbacks.
   void triggerOnEnter() {
-    if (currentSlideIndex >= 0 && currentSlideIndex < widget.bubbleSlides.length) {
+    if (currentSlideIndex >= 0 &&
+        currentSlideIndex < widget.bubbleSlides.length) {
       VoidCallback? callback = widget.bubbleSlides[currentSlideIndex].onEnter;
       if (callback != null) {
         callback();
@@ -145,11 +161,17 @@ class _BubbleShowcaseState extends State<BubbleShowcase> with WidgetsBindingObse
 
   /// Allows to trigger exit callbacks.
   void triggerOnExit() {
-    if (currentSlideIndex >= 0 && currentSlideIndex < widget.bubbleSlides.length) {
+    if (currentSlideIndex >= 0 &&
+        currentSlideIndex < widget.bubbleSlides.length) {
       VoidCallback? callback = widget.bubbleSlides[currentSlideIndex].onExit;
       if (callback != null) {
         callback();
       }
     }
   }
+}
+
+/// Notification Used to tell the [BubbleShowcase] to continue the showcase
+class BubbleShowcaseNotification extends Notification {
+  const BubbleShowcaseNotification();
 }

--- a/lib/src/showcase.dart
+++ b/lib/src/showcase.dart
@@ -105,6 +105,7 @@ class _BubbleShowcaseState extends State<BubbleShowcase>
   }
 
   bool processNotification(BubbleShowcaseNotification notif) {
+    if (isFinished) return true;
     goToNextEntryOrClose(currentSlideIndex + 1);
     return true;
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -30,10 +30,16 @@ class Position {
   });
 
   @override
-  String toString() => 'Position(top: $top, right: $right, bottom: $bottom, left: $left)';
+  String toString() =>
+      'Position(top: $top, right: $right, bottom: $bottom, left: $left)';
 
   @override
-  bool operator ==(Object other) => other is Position && top == other.top && right == other.right && bottom == other.bottom && left == other.left;
+  bool operator ==(Object other) =>
+      other is Position &&
+      top == other.top &&
+      right == other.right &&
+      bottom == other.bottom &&
+      left == other.left;
 
   @override
   int get hashCode {
@@ -59,7 +65,10 @@ class OverlayPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    canvas.saveLayer(Offset.zero & size, Paint()); // Thanks to https://stackoverflow.com/a/51548959.
+    canvas.saveLayer(
+      Offset.zero & size,
+      Paint(),
+    ); // Thanks to https://stackoverflow.com/a/51548959.
     canvas.drawColor(_slide.boxShadow.color, BlendMode.dstATop);
     _slide.shape.drawOnCanvas(
       canvas,
@@ -75,5 +84,34 @@ class OverlayPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(OverlayPainter oldOverlay) => oldOverlay._position != _position;
+  bool shouldRepaint(OverlayPainter oldOverlay) =>
+      oldOverlay._position != _position;
+}
+
+class OverlayClipper extends CustomClipper<Path> {
+  final BubbleSlide _slide;
+  final Position _position;
+
+  const OverlayClipper(this._slide, this._position);
+
+  @override
+  Path getClip(Size size) {
+    final path = Path();
+    path.addRect(Rect.fromLTWH(0, 0, size.width, size.height));
+    _slide.shape.makePath(
+      path,
+      Rect.fromLTRB(
+        _position.left,
+        _position.top,
+        _position.right,
+        _position.bottom,
+      ),
+    );
+    path.fillType = PathFillType.evenOdd;
+
+    return path;
+  }
+
+  @override
+  bool shouldReclip(covariant CustomClipper oldClipper) => false;
 }


### PR DESCRIPTION
In my use case, I require the user to click some buttons inside the highlighted area, afterwards I wanted to continue the showcase, so what I did is:

- Added `PassthroughMode` enum that declares the behavior of the passthrough, by default `RelativeBubbleSlide` uses the `PassthroughMode.NONE` option which absorbs all pointer events and advances the showcase, as it currently is doing.
- When `PassthroughMode.INSIDE_WITH_NOTIFICATION` is used, several things happen:
  - A CustomClipper is used instead of a CustomPainter, which clips around the highlighted area, leaving the highlighted area exposed to pointer events
  - The default behavior of continuing the showcase when the user clicks anywhere is removed. To continue the showcase, the user MUST dispatch a `BubbleShowcaseNotification` Notification that lets the `BubbleShowcase` object know that it should continue. 
    - This is thought so the user can easily do async tasks and then notifiy the BubbleShowcase when it should continue.
    - Pretty useful as well if you want to wrap the BubbleSlide with a GestureRecognizer to override the default behavior of the button or element you want the user to interact with.
- Added the option of "padding" (Default of 0, like it currently is) to the highlighted area. The amount of padding is added to the Position that is gotten from the highlighted widget.
- Updated the example with a 4th slide which includes `highlightPadding` and `PassthroughMode.INSIDE_WITH_NOTIFICATION`
- Made a comment regarding the `initialDelay` property be a doc comment instead of being a normal comment.

Default current behavior is retained while adding the new options and functionality.